### PR TITLE
Pirate Patchers - Issue #9 - Add Feature Normalization Wrapper in src/preprocess.py

### DIFF
--- a/src/preprocess.py
+++ b/src/preprocess.py
@@ -17,3 +17,30 @@ def normalize(df, cols):
 def detect_duplicates(df):
     dup=df.duplicated()
     return df[dup]
+
+import pickle
+from pathlib import Path
+
+ARTIFACTS_DIR = Path("artifacts")
+SCALER_PATH = ARTIFACTS_DIR / "scaler.pkl"
+
+def normalize_features(df, feature_cols, target_col):
+
+    #ensuring that target is not normalised
+    feature_cols = [col for col in feature_cols if col != target_col]
+
+    #applying normalisation
+    df, scaler = normalize(df, feature_cols)
+
+    #creating artifacts directory if not exists
+    ARTIFACTS_DIR.mkdir(parents=True, exist_ok=True)
+
+    with open(SCALER_PATH, "wb") as f:
+        pickle.dump(scaler, f)
+
+    #printing transformed values
+    print("✅ Feature range after MinMax scaling:")
+    print(f"Min: {df[feature_cols].min().min():.4f}")
+    print(f"Max: {df[feature_cols].max().max():.4f}")
+
+    return df

--- a/src/run_normalization.py
+++ b/src/run_normalization.py
@@ -1,0 +1,13 @@
+import pandas as pd
+from preprocess import normalize_features
+
+def main():
+    df = pd.read_csv("data/processed/structured_sample.csv")
+
+    feature_cols = ["price", "count"]   # example numeric features
+    target_col = "count"                 # target should NOT be normalized
+
+    normalize_features(df, feature_cols, target_col)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Fixed #9 
Pirate Patchers
Implementing MinMax normalization and save scaler for future inference.
<img width="963" height="147" alt="image" src="https://github.com/user-attachments/assets/bacda644-2629-46c3-aa7f-3a23e851a9ee" />
