### PR TITLE
Pirate Patchers - Issue #10 - Implement logging instead of printing 

### DIFF
--- a/src/pipeline/pipeline.py
+++ b/src/pipeline/pipeline.py
@@ -1,18 +1,44 @@
+import argparse
+import logging 
+import os
+#ldir: log directory lfile: log file
+ldir = "logs"
+lfile = os.path.join(ldir, "pipeline.log")
+
+os.makedirs(ldir, exist_ok=True)
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s | %(levelname)s | %(message)s",
+    handlers=[
+        logging.FileHandler(lfile),
+        logging.StreamHandler()
+    ],
+)
+
+logger = logging.getLogger(__name__)
+#info
 def run_stage(stage):
-    print(f"Running stage: {stage}")
+    logger.info(f"Running stage: {stage}")
     # placeholder routing
     if stage=="ocr":
-        pass
+        logger.info("OCR stage started")
     elif stage=="preprocess":
-        pass
+        logger.info("preprocessor stage started")
     elif stage=="train_lstm":
-        pass
+        logger.info("train_lstm stage started")
     elif stage=="all":
-        pass
+        logger.info("full pipeline")
+    else:
+        #warning
+        logger.warning(f"Unknown stage: {stage}")
+    
 
 if __name__=="__main__":
-    import argparse
     p=argparse.ArgumentParser()
-    p.add_argument("--stage")
-    args=p.parse_args()
-    run_stage(args.stage)
+    p.add_argument("--stage", required = True)
+    args = p.parse_args()
+    try: #error
+        run_stage(args.stage)
+    except Exception as e: 
+        logger.error(f"Pipeline failed: {e}", exc_info = True)


### PR DESCRIPTION
Pirate Patchers 
Issue #10 

- Added logging functionality to track pipeline stages and errors.
- time stamps measured by asctime
- logger info, error and warning used 
- written to logs/pipeline.log
- unaffected pipeline execution

